### PR TITLE
Add simple module support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist/literally.development.handlebars
 dist/literally.development.js
+dist

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "scripts": {
         "build": "node ./node_modules/literally-cli/dist/literally.js --format node --output dist --name literally README.md",
         "literally-dev": "./literally",
-        "bootstrap": "yarn literally-dev --format node --output dist --name literally README.md",
+        "bootstrap": "yarn literally-dev --format commonjs --output dist --name literally README.md",
         "test": "yarn build && yarn bootstrap && yarn bootstrap"
     }
 }


### PR DESCRIPTION
`exports` and `require()` are now (barely!) polyfilled.  The simplicity is intentional!  Alas, it is looking increasing likely some flavor of babel integration will be required.