### PR TITLE
Add `type="module"` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ These formats are availble for output:
 
 ```javascript
 const COMPILERS = {
-    commonjs: runwatch.bind(compile_to_commonjs),
+    js: runwatch.bind(compile_to_js),
     html: runwatch.bind(compile_to_html),
     "inline-html": runwatch.bind(compile_to_inlinehtml),
     block: runwatch.bind(compile_to_blocks),
@@ -215,10 +215,10 @@ const COMPILERS = {
 ```
 
 
-## `commonjs` Format
+## `js` Format
 
 ```javascript
-function compile_to_commonjs(file, output, name) {
+function compile_to_js(file, output, name) {
     const md_name = path.parse(file).name;
     const out_name = name || md_name;
     const path_prefix = path.join(output, out_name);
@@ -449,12 +449,12 @@ for its own `html` output formats:
         <link rel="stylesheet" href="{{{href}}}">
         {{/if}}
         {{#if javascript}}
-        <script>
+        <script type="module">
             {{{indent javascript}}}
         </script>
         {{/if}}
         {{#if src}}
-        <script src="{{{src}}}"></script>
+        <script type="module" src="{{{src}}}"></script>
         {{/if}}
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
         "puppeteer": "^3.3.0"
     },
     "devDependencies": {
-        "literally-cli": "0.0.4"
+        "literally-cli": "0.0.8"
     },
     "bin": {
         "literally": "literally"
     },
     "scripts": {
-        "build": "node ./node_modules/literally-cli/dist/literally.js --format node --output dist --name literally README.md",
+        "build": "node ./node_modules/literally-cli/dist/literally.js --format commonjs --output dist --name literally README.md",
         "literally-dev": "./literally",
-        "bootstrap": "yarn literally-dev --format commonjs --output dist --name literally README.md",
+        "bootstrap": "yarn literally-dev --format js --output dist --name literally README.md",
         "test": "yarn build && yarn bootstrap && yarn bootstrap"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,11 +1169,12 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-literally-cli@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/literally-cli/-/literally-cli-0.0.4.tgz#81338f6c211877350f52c66653874a1141db0c36"
-  integrity sha512-wDwvlxowLgll72Plls221Mr8dgckaqZNBI8rVHp+GIDmvuKhh+NI8Yy02wBlaZ4Rf8yy8SsEkAYuFInuWmayfg==
+literally-cli@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/literally-cli/-/literally-cli-0.0.8.tgz#b9a22c54a2e12c826ff426b1a7714304d4a7330d"
+  integrity sha512-RFgA/sV/cjgypTggestfrujRE9SG3W7cg5ZCgnOhfqtQJorn3892WLp1LMLQONyyLk1noCPcWeqPmjBRZ/Yclw==
   dependencies:
+    "@babel/core" "^7.13.10"
     chalk "^4.1.0"
     commander "^5.1.0"
     eslint "^7.1.0"


### PR DESCRIPTION
Allows ES-module syntax in `javascript` code blocks.